### PR TITLE
Create a basic utility for Open States API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,6 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
+# local config files
 .env
-
+config/development.js

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The #1 requested feature for both projects is the ability to be notified when up
 
 ## Local Development
 
-TODO
+1. Create a `config/development.js` file for local settings.
+1. Fill it with your information, referencing `config/default.js` for available
+   settings.
 
 ## Production Deployment (Heroku)
 

--- a/config/default.js
+++ b/config/default.js
@@ -22,4 +22,8 @@ cfg.twilio = {
   authToken: process.env.TWILIO_AUTH_TOKEN || ''
 }
 
+cfg.openstates = {
+  apiKey: process.env.OPENSTATES_API_KEY || ''
+}
+
 module.exports = cfg

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/Twilio-org/open-data-notifications#readme",
   "devDependencies": {
     "jest-cli": "^20.0.1",
+    "nock": "^9.0.13",
     "standard": "^10.0.2",
     "supertest": "^3.0.0",
     "supertest-as-promised": "^4.0.2"
@@ -46,6 +47,7 @@
     "config": "^1.26.1",
     "express": "^4.15.2",
     "helmet": "^3.6.0",
+    "request": "^2.81.0",
     "twilio": "^3.0.0"
   }
 }

--- a/src/openstates.js
+++ b/src/openstates.js
@@ -27,7 +27,7 @@ const openstates = {
         if (err) return reject(err)
 
         return resolve({
-          status: response.status,
+          status: response.statusCode,
           body: JSON.parse(body)
         })
       })

--- a/src/openstates.js
+++ b/src/openstates.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const request = require('request')
+const config = require('config')
+
+const API_BASE = 'https://openstates.org/api/v1'
+const API_KEY = config.get('openstates.apiKey')
+
+const openstates = {
+
+  /**
+   * Expose a reference to the API base URL.
+   */
+  API_BASE,
+
+  /**
+   * Returns the JSON from an Open States API request method.
+   */
+  get (method) {
+    let requestOptions = {
+      url: `${API_BASE}/${method}`,
+      headers: { 'x-api-key': API_KEY }
+    }
+
+    return new Promise((resolve, reject) => {
+      request(requestOptions, (err, response, body) => {
+        if (err) return reject(err)
+
+        return resolve({
+          status: response.status,
+          body: JSON.parse(body)
+        })
+      })
+    })
+  }
+
+}
+
+module.exports = openstates

--- a/test/openstates.test.js
+++ b/test/openstates.test.js
@@ -1,0 +1,20 @@
+/* global describe, it, expect */
+'use strict'
+
+const openstates = require('../src/openstates')
+const nock = require('nock')
+
+// Set up our mocked API responses
+nock(openstates.API_BASE)
+  .get('/metadata/KS').reply(200, { name: 'Kansas' })
+
+describe('get', () => {
+  it('Returns a JSON response from the Open States API', done => {
+    openstates.get('/metadata/KS', result => {
+      expect(result.status).toBe(200)
+      expect(result.body.name).toBe('Kansas')
+
+      done()
+    }).catch(done)
+  })
+})


### PR DESCRIPTION
Added a configuration option for the Open States API Key, as well as a
mechanism for having a `.gitignore`'d local config file.

Closes #1