### PR TITLE
Add Deploy to Heroku Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ npm test
 
 ## Production Deployment (Heroku)
 
+### Push-Button Deployment
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+### Command Line Deployment
+
 To run this application on Heroku, you will need to install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).  You can create a new application for the project with:
 
 ```

--- a/app.json
+++ b/app.json
@@ -1,0 +1,20 @@
+{
+  "name": "Open Data Notifications",
+  "description": "A general purpose SMS notification system for open data sources built using Node.js and Twilio.",
+  "repository": "https://github.com/Twilio-org/open-data-notifications",
+  "keywords": ["node", "twilio", "sms", "open data", "notifications"],
+  "env": {
+    "PRODUCTION_URL": {
+      "description": "The URL to this heroku app. Ex: http://example-open-data.herokuapp.com"
+    },
+    "TWILIO_ACCOUNT_SID": {
+      "description": "Account SID from your Twilio Console at https://www.twilio.com/console"
+    },
+    "TWILIO_AUTH_TOKEN": {
+      "description": "Auth Token from your Twilio Console at https://www.twilio.com/console"
+    },
+    "OPENSTATES_API_KEY": {
+      "description": "OpenStates.org API key available at https://openstates.org/api/register/"
+    }
+  }
+}


### PR DESCRIPTION
- Add app.json template for Heroku Deployment
- Add "Deploy to Heroku" button to README

The initial implementation of the `app.json` configuration simply describes the project and specifies the required environment variables. As the project evolves, we should maintain this configuration in order to provide a low friction option for deploying this notification service.

### Readme Image
> ![image](https://cloud.githubusercontent.com/assets/76180/26509409/78e9df4e-420d-11e7-8e4a-4315bf112459.png)

### Heroku New App Creation Image
> ![image](https://cloud.githubusercontent.com/assets/76180/26509357/45a98bd4-420d-11e7-8d39-5c347c6e7bba.png)
